### PR TITLE
update to 1.5.4 and runtime to 5.15

### DIFF
--- a/net.sourceforge.Chessx.appdata.xml
+++ b/net.sourceforge.Chessx.appdata.xml
@@ -24,6 +24,7 @@ browse, edit, add, organize, analyze, etc.
 		</ul>
 	</description>
 	<releases>
+	<release version="1.5.4" date="2020-05-12"/>
     	<release version="1.5.0" date="2019-05-05"/>
     	<release version="1.4.6" date="2017-04-14"/>
   	</releases>
@@ -32,7 +33,7 @@ browse, edit, add, organize, analyze, etc.
 			<image>http://i1-win.softpedia-static.com/screenshots/ChessX_1.png</image>
 		</screenshot>
 	</screenshots>
-	<url type="homepage">http://chessx.sourceforge.net/</url>
+	<url type="homepage">https://chessx.sourceforge.io</url>
 	<content_rating type="oars-1.1">
 		<content_attribute id="violence-cartoon">none</content_attribute>
 		<content_attribute id="violence-fantasy">none</content_attribute>

--- a/net.sourceforge.Chessx.json
+++ b/net.sourceforge.Chessx.json
@@ -12,8 +12,7 @@
         "--socket=pulseaudio",
         "--socket=wayland",
         "--share=network",
-        "--device=dri",
-        "--env=QT_QPA_PLATFORM=xcb"
+        "--device=dri"
     ],
     "modules": [
         {

--- a/net.sourceforge.Chessx.json
+++ b/net.sourceforge.Chessx.json
@@ -10,7 +10,6 @@
         "--socket=x11",
         "--share=ipc",
         "--socket=pulseaudio",
-        "--socket=wayland",
         "--share=network",
         "--device=dri"
     ],

--- a/net.sourceforge.Chessx.json
+++ b/net.sourceforge.Chessx.json
@@ -2,7 +2,7 @@
     "app-id": "net.sourceforge.Chessx",
     "branch": "stable",
     "runtime": "org.kde.Platform",
-    "runtime-version": "5.12",
+    "runtime-version": "5.15",
     "sdk": "org.kde.Sdk",
     "rename-icon": "chessx",
     "command": "chessx",
@@ -12,7 +12,8 @@
         "--socket=pulseaudio",
         "--socket=wayland",
         "--share=network",
-        "--device=dri"
+        "--device=dri",
+        "--env=QT_QPA_PLATFORM=xcb"
     ],
     "modules": [
         {
@@ -27,8 +28,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://downloads.sourceforge.net/project/chessx/chessx/1.5.0/chessx-1.5.0.tgz",
-                    "sha256": "d130ad3220821da9ea19e7228222a5528fabca3ca06bc41b4d7f702454f63827",
+                    "url": "https://downloads.sourceforge.net/project/chessx/chessx/1.5.4/chessx-1.5.4.tgz",
+                    "sha256": "e2dbacff2a6c055cfbe4ce0344331f77262867e228a5fe2895e6c242772065a8",
                     "strip-components": 2
                 },
                 {
@@ -38,6 +39,10 @@
                 {
                     "type": "file",
                     "path": "net.sourceforge.Chessx.appdata.xml"
+                },
+                {
+                    "type": "shell",
+                    "commands": [ "sed -i -r '/chessx_(da|fr|it|cz|ru)/d' resources.qrc" ]
                 }
             ],
             "post-install": [


### PR DESCRIPTION
- update chessx to 1.5.4
   build issue: https://sourceforge.net/p/chessx/bugs/272/
- update runtime to 5.15
- homepage moved
- fixes #5 